### PR TITLE
Implement Issue #3: Add feature to control publishing of posts

### DIFF
--- a/app/Http/Controllers/MarkdownFileParser.php
+++ b/app/Http/Controllers/MarkdownFileParser.php
@@ -221,7 +221,7 @@ class MarkdownFileParser extends Controller
         }
 
         try {
-            $created_at = Carbon::parse($validated['published']);
+            $published_at = Carbon::parse($validated['published']);
         } catch (\Throwable $th) {
             throw new Exception('Could not parse publish date', 1);
         }
@@ -244,7 +244,7 @@ class MarkdownFileParser extends Controller
             'body'           => $validated['body'],
             'description'    => $validated['description'],
             'featured_image' => $validated['featured_image'],
-            'created_at'     => $created_at,
+            'published_at'     => $published_at,
             'updated_at'     => $updated_at,
             'user_id'        => $author->id,
             'tags'           => $tags,

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -177,6 +177,7 @@ class PostController extends Controller
         $this->authorize('update', $post);
 
         $post->published_at = now();
+        $post->save();
         return back()->with('success', 'Successfully Published Post!');
     }
     
@@ -191,6 +192,7 @@ class PostController extends Controller
         $this->authorize('update', $post);
 
         $post->published_at = null;
+        $post->save();
         return back()->with('success', 'Successfully Unpublished Post!');
     }
 

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -102,6 +102,8 @@ class PostController extends Controller
      */
     public function show(Post $post)
     {
+        $this->authorize('view', $post);
+
         // Generate formatted HTML from markdown
         $markdown = (new MarkdownConverter($post->body))->toHtml();
 

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -167,6 +167,35 @@ class PostController extends Controller
     }
 
     /**
+     * Update the published_at date in the specified resource in storage.
+     *
+     * @param  \App\Models\Post  $post
+     * @return \Illuminate\Http\Response
+     */
+    public function publish(Post $post)
+    {
+        $this->authorize('update', $post);
+
+        $post->published_at = now();
+        return back()->with('success', 'Successfully Published Post!');
+    }
+    
+    /**
+     * Update the published_at date in the specified resource in storage.
+     *
+     * @param  \App\Models\Post  $post
+     * @return \Illuminate\Http\Response
+     */
+    public function unpublish(Post $post)
+    {
+        $this->authorize('update', $post);
+
+        $post->published_at = null;
+        return back()->with('success', 'Successfully Unpublished Post!');
+    }
+
+
+    /**
      * Remove the specified resource from storage.
      *
      * @param  \App\Models\Post  $post

--- a/app/Http/Livewire/LatestBlogPosts.php
+++ b/app/Http/Livewire/LatestBlogPosts.php
@@ -12,11 +12,11 @@ class LatestBlogPosts extends Component
 
     public function render()
     {
-        $posts = Post::orderBy('created_at', 'desc')->paginate(12);
+        $posts = Post::paginate(12);
 
         // If we are in demo mode we only show the posts made by the factory.
         if (config('blog.demoMode')) {
-            $posts = Post::where('id', '<=', 36)->orderBy('created_at', 'desc')->paginate(12);
+            $posts = Post::where('id', '<=', 36)->orderBy('published_at', 'desc')->paginate(12);
         }
         
         return view('livewire.latest-blog-posts', [

--- a/app/Http/Requests/StorePostRequest.php
+++ b/app/Http/Requests/StorePostRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use Carbon\Carbon;
 use Illuminate\Foundation\Http\FormRequest;
 
 class StorePostRequest extends FormRequest
@@ -17,6 +18,23 @@ class StorePostRequest extends FormRequest
     }
 
     /**
+     * Prepare the data for validation.
+     * 
+     * Thanks to SO user BenSampo!
+     * @see https://stackoverflow.com/a/54480210/5700388
+     *
+     * @return void
+     */
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'published_at' => $this->is_draft 
+                ? null
+                : Carbon::parse($this->published_at),
+        ]);
+    }
+
+    /**
      * Get the validation rules that apply to the request.
      *
      * @return array
@@ -29,6 +47,7 @@ class StorePostRequest extends FormRequest
             'description' => 'nullable|string|max:255',
             'featured_image' => 'nullable|url|max:255',
             'tags' => 'nullable|json',
+            'published_at' => 'nullable|date|after:1970-12-31T12:00|before:2038-01-09T03:14',
         ];
     }
 }

--- a/app/Http/Requests/UpdatePostRequest.php
+++ b/app/Http/Requests/UpdatePostRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use Carbon\Carbon;
 use Illuminate\Foundation\Http\FormRequest;
 
 class UpdatePostRequest extends FormRequest
@@ -17,6 +18,23 @@ class UpdatePostRequest extends FormRequest
     }
 
     /**
+     * Prepare the data for validation.
+     * 
+     * Thanks to SO user BenSampo!
+     * @see https://stackoverflow.com/a/54480210/5700388
+     *
+     * @return void
+     */
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'published_at' => $this->is_draft 
+                ? null
+                : Carbon::parse($this->published_at),
+        ]);
+    }
+
+    /**
      * Get the validation rules that apply to the request.
      *
      * @return array
@@ -29,6 +47,7 @@ class UpdatePostRequest extends FormRequest
             'description' => 'nullable|string|max:255',
             'featured_image' => 'nullable|url|max:255',
             'tags' => 'nullable|json',
+            'published_at' => 'nullable|date|after:1970-12-31T12:00|before:2038-01-09T03:14',
         ];
     }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -46,9 +46,9 @@ class Post extends Model
     {
         parent::boot();
     
-        // Order by latest posts by default
+        // Order by latest posts by default, with draft posts first
         static::addGlobalScope('order', function (Builder $builder) {
-            $builder->orderBy('published_at', 'desc');
+            $builder->orderByRaw('-published_at');
         });
 
         // Filter out posts that are not published

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -102,7 +102,7 @@ class Post extends Model
      */
     public function isPublished(): bool
     {
-        return $this->published_at->isPast();
+        return ($this->published_at !== null) && $this->published_at->isPast();
     }
 
     /**

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -24,6 +24,7 @@ class Post extends Model
         'description',
         'featured_image',
         'tags',
+        'published_at',
     ];
 
     /**

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Http\Controllers\MarkdownFileParser;
+use App\Scopes\PublishedScope;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Builder;
@@ -32,6 +33,7 @@ class Post extends Model
      */
     protected $casts = [
         'tags' => 'array',
+        'published_at' => 'datetime',
     ];
 
     /**
@@ -45,10 +47,13 @@ class Post extends Model
     
         // Order by latest posts by default
         static::addGlobalScope('order', function (Builder $builder) {
-            $builder->orderBy('created_at', 'desc');
+            $builder->orderBy('published_at', 'desc');
         });
-    }
 
+        // Filter out posts that are not published
+        static::addGlobalScope(new PublishedScope);
+    }
+    
     /**
      * Get the route key for the model.
      *
@@ -88,6 +93,16 @@ class Post extends Model
                 ? asset('storage/default.jpg')
                 : $value
         );
+    }
+
+    /**
+     * Check if the post is published by comparing the published_at date with the current date. 
+     * 
+     * @return bool
+     */
+    public function isPublished(): bool
+    {
+        return $this->published_at->isPast();
     }
 
     /**

--- a/app/Policies/PostPolicy.php
+++ b/app/Policies/PostPolicy.php
@@ -31,7 +31,12 @@ class PostPolicy
      */
     public function view(User $user, Post $post)
     {
-        return true;
+        if ($post->isPublished()) {
+            return true;
+        }
+        
+        // Determine whether the user can view a post that is scheduled to be published in the future which inherits the update permissions.
+        return $user->can('update', $post);
     }
 
     /**

--- a/app/Scopes/PublishedScope.php
+++ b/app/Scopes/PublishedScope.php
@@ -1,0 +1,27 @@
+<?php
+ 
+namespace App\Scopes;
+ 
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+use Illuminate\Support\Facades\Auth;
+
+class PublishedScope implements Scope
+{
+    /**
+     * Apply the scope to a given Eloquent query builder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $builder
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return void
+     */
+    public function apply(Builder $builder, Model $model)
+    {
+		if (Auth::check() && Auth::user()->is_admin) {
+			return;
+		}
+
+        $builder->where('published_at', '<=', now());
+    }
+}

--- a/app/Scopes/PublishedScope.php
+++ b/app/Scopes/PublishedScope.php
@@ -18,10 +18,17 @@ class PublishedScope implements Scope
      */
     public function apply(Builder $builder, Model $model)
     {
+        // If user is admin we don't want to remove published posts
 		if (Auth::check() && Auth::user()->is_admin) {
 			return;
 		}
-
+        
+        // Apply the filter
         $builder->where('published_at', '<=', now());
+
+        // If the user has posts we do a special case to make sure they can see their own posts
+		if (Auth::check() && Auth::user()->is_author) {
+            return $builder->orWhere('user_id', Auth::id());
+        }
     }
 }

--- a/config/blog.php
+++ b/config/blog.php
@@ -11,6 +11,9 @@ return [
 	// Should tags be shown on the post card component? Feel free to disable this to reduce clutter.
 	'showTagsOnPostCard' => env('BLOGKIT_TAGS_ENABLED_ON_CARDS', true), // Default: true
 
+	// Should the updated at time be shown on edited posts?
+	'showUpdatedAt' => true, // Default: true
+
 	// Can users register for accounts? Note that while disabling this removes the registration route completely, you can still log in by going to the /login route.
 	'allowRegistrations' => env('BLOGKIT_REGISTRATIONS_ENABLED', true), // Default: true
 

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -27,7 +27,7 @@ class PostFactory extends Factory
             'description' => $this->faker->sentence(),
             'body' => $this->getMarkdown(),
             'featured_image' => $this->getFeaturedImage(),
-            'created_at' => $this->faker->dateTimeThisYear(),
+            'published_at' => rand(0, 20) < 1 ? null : $this->faker->dateTimeThisYear(),
             'tags' => $this->getTags(),
         ];
     }

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -20,8 +20,14 @@ class PostFactory extends Factory
     {
         $title = $this->faker->sentence();
 
+        $user = User::all()->random();
+        if (!$user->is_author) {
+            $user->is_author = true; // Make sure the user becomes an author
+            $user->save();
+        }
+
         return [
-            'user_id' => User::pluck('id')->random(),
+            'user_id' => $user->id,
             'title' => $title,
             'slug' => Str::slug($title),
             'description' => $this->faker->sentence(),

--- a/database/migrations/2022_02_22_183431_add_published_at_to_posts_table.php
+++ b/database/migrations/2022_02_22_183431_add_published_at_to_posts_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->timestamp('published_at')
+                ->after('updated_at')
+                ->default(now())
+                ->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropColumn('published_at');
+        });
+    }
+};

--- a/database/migrations/2022_02_22_183431_add_published_at_to_posts_table.php
+++ b/database/migrations/2022_02_22_183431_add_published_at_to_posts_table.php
@@ -16,7 +16,6 @@ return new class extends Migration
         Schema::table('posts', function (Blueprint $table) {
             $table->timestamp('published_at')
                 ->after('updated_at')
-                ->default(now())
                 ->nullable();
         });
     }

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1044,6 +1044,10 @@ select {
   margin-top: auto;
   margin-bottom: auto;
 }
+.-mx-3 {
+  margin-left: -0.75rem;
+  margin-right: -0.75rem;
+}
 .ml-3 {
   margin-left: 0.75rem;
 }
@@ -1277,6 +1281,9 @@ select {
 .flex-row {
   flex-direction: row;
 }
+.flex-row-reverse {
+  flex-direction: row-reverse;
+}
 .flex-col {
   flex-direction: column;
 }
@@ -1300,6 +1307,9 @@ select {
 }
 .justify-between {
   justify-content: space-between;
+}
+.justify-evenly {
+  justify-content: space-evenly;
 }
 .justify-items-center {
   justify-items: center;
@@ -1469,13 +1479,13 @@ select {
   --tw-bg-opacity: 1;
   background-color: rgb(107 114 128 / var(--tw-bg-opacity));
 }
-.bg-gray-200 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(229 231 235 / var(--tw-bg-opacity));
-}
 .bg-red-300 {
   --tw-bg-opacity: 1;
   background-color: rgb(252 165 165 / var(--tw-bg-opacity));
+}
+.bg-gray-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(229 231 235 / var(--tw-bg-opacity));
 }
 .bg-opacity-10 {
   --tw-bg-opacity: 0.1;
@@ -1767,6 +1777,10 @@ select {
 .text-gray-800 {
   --tw-text-opacity: 1;
   color: rgb(31 41 55 / var(--tw-text-opacity));
+}
+.text-indigo-300 {
+  --tw-text-opacity: 1;
+  color: rgb(165 180 252 / var(--tw-text-opacity));
 }
 .underline {
   -webkit-text-decoration-line: underline;
@@ -2199,6 +2213,10 @@ pre code.torchlight .line-number, pre code.torchlight .summary-caret {
 .dark .dark\:text-gray-200 {
   --tw-text-opacity: 1;
   color: rgb(229 231 235 / var(--tw-text-opacity));
+}
+.dark .dark\:text-indigo-300 {
+  --tw-text-opacity: 1;
+  color: rgb(165 180 252 / var(--tw-text-opacity));
 }
 .dark .dark\:opacity-90 {
   opacity: 0.9;

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1487,8 +1487,22 @@ select {
   --tw-bg-opacity: 1;
   background-color: rgb(229 231 235 / var(--tw-bg-opacity));
 }
+.bg-gray-400 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(156 163 175 / var(--tw-bg-opacity));
+}
+.bg-green-400 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(74 222 128 / var(--tw-bg-opacity));
+}
 .bg-opacity-10 {
   --tw-bg-opacity: 0.1;
+}
+.bg-opacity-50 {
+  --tw-bg-opacity: 0.5;
+}
+.bg-opacity-0 {
+  --tw-bg-opacity: 0;
 }
 .fill-green-400 {
   fill: #4ade80;
@@ -1799,6 +1813,12 @@ select {
 .opacity-100 {
   opacity: 1;
 }
+.opacity-10 {
+  opacity: 0.1;
+}
+.opacity-50 {
+  opacity: 0.5;
+}
 .shadow-sm {
   --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
   --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
@@ -1983,6 +2003,9 @@ pre code.torchlight .line-number, pre code.torchlight .summary-caret {
   --tw-bg-opacity: 1;
   background-color: rgb(209 213 219 / var(--tw-bg-opacity));
 }
+.hover\:bg-opacity-100:hover {
+  --tw-bg-opacity: 1;
+}
 .hover\:text-gray-500:hover {
   --tw-text-opacity: 1;
   color: rgb(107 114 128 / var(--tw-text-opacity));
@@ -2121,6 +2144,9 @@ pre code.torchlight .line-number, pre code.torchlight .summary-caret {
 }
 .group:hover .group-hover\:visible {
   visibility: visible;
+}
+.group:hover .group-hover\:bg-opacity-100 {
+  --tw-bg-opacity: 1;
 }
 .group:hover .group-hover\:opacity-100 {
   opacity: 1;

--- a/resources/views/components/post-card.blade.php
+++ b/resources/views/components/post-card.blade.php
@@ -12,14 +12,23 @@
                 
         <a href="{{ route('posts.show', $post) }}">
             <h3 class="mb-2 text-xl font-bold tracking-tight text-gray-900 dark:text-white break-words">
+                @if($post->isPublished())
                 {{ $post->title }}
+                @else
+                <span class="opacity-75" title="This post has not yet been published">
+                    Draft: 
+                </span>
+                <i>{{ $post->title }}</i>
+                @endif
             </h3>
         </a>
         
         <p class="mb-3 text-sm font-normal text-gray-700 dark:text-gray-400 overflow-hidden text-ellipsis">
             By <x-link :href="route('posts.index', ['author' => $post->author])" rel="author">{{ $post->author->name }}</x-link>
+            @if($post->isPublished())
             <span class="opacity-75" role="none">&bullet;</span>
-            <time datetime="{{ $post->created_at }}">{{ $post->created_at->format('Y-m-d') }}</time>.
+            <time datetime="{{ $post->published_at }}" title="Published {{ $post->published_at }}">{{ $post->published_at->format('Y-m-d') }}</time>.
+            @endif
             @if(config('blog.allowComments'))
             <span class="inline float-right">
                 <span class="sr-only">

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -40,13 +40,13 @@
                                 <tr>
                                     <x-th>Author</x-th>
                                     <x-th>Title</x-th>
-                                    <x-th>Date</x-th>
+                                    <x-th>Published</x-th>
                                     <x-th>Actions</x-th>
                                 </tr>
                             </thead>
                             <tbody class="text-gray:700 dark:text-gray-300">
                                 @foreach ($posts as $post)
-                                <tr>
+                                <tr class="group">
                                     <x-td>
                                         <a href="{{ route('posts.index', ['author' => $post->author]) }}" rel="author" class="hover:text-indigo-500">
                                             {{ $post->author->name }}
@@ -60,7 +60,17 @@
                                         </div>
                                     </x-td>
                                     <x-td>
-                                        {{ $post->created_at->format('Y-m-d')}}
+                                        @if($post->isPublished())
+                                        <span title="{{ $post->published_at }}">{{ $post->published_at->format('Y-m-d') }}</span>
+                                        @else
+                                        <span class="rounded-lg bg-gray-400 text-gray-900 px-2 py-1 text-xs uppercase font-bold" title="This post has not yet been published.">Draft</span>
+                                        @can('update', $post)
+                                        <form action="{{ route('posts.publish', ['post' => $post]) }}" method="POST" class="inline ml-2">
+                                            @csrf
+                                            <button type="submit" title="Click to publish the post" class="rounded-lg opacity-0 group-hover:opacity-100 transition-opacity bg-green-400 text-green-900 px-2 py-1 text-xs uppercase font-bold">Publish</button>
+                                        </form>
+                                        @endcan
+                                        @endif
                                     </x-td>
                                     <x-td class="text-center">
                                         @can('update', $post)
@@ -104,9 +114,19 @@
                                     </x-td>
                                 </tr>
                                 <tr>
-                                    <x-th>Date</x-th>
+                                    <x-th>Published</x-th>
                                     <x-td>
-                                        {{ $post->created_at->format('Y-m-d')}}
+                                        @if($post->isPublished())
+                                        <span title="{{ $post->published_at }}">{{ $post->published_at->format('Y-m-d') }}</span>
+                                        @else
+                                        <span class="rounded-lg bg-gray-400 text-gray-900 px-2 py-1 text-xs uppercase font-bold" title="This post has not yet been published.">Draft</span>
+                                        @can('update', $post)
+                                        <form action="{{ route('posts.publish', ['post' => $post]) }}" method="POST" class="inline ml-2">
+                                            @csrf
+                                            <button type="submit" title="Click to publish the post" class="rounded-lg opacity-0 group-hover:opacity-100 transition-opacity bg-green-400 text-green-900 px-2 py-1 text-xs uppercase font-bold">Publish</button>
+                                        </form>
+                                        @endcan
+                                        @endif
                                     </x-td>
                                 </tr>
                                 <tr>

--- a/resources/views/post/create.blade.php
+++ b/resources/views/post/create.blade.php
@@ -45,12 +45,34 @@
                             @error('featured_image') <span class="text-red-500">{{ $message }}</span> @enderror
                         </div>
 
+                        <div class="mt-3">
+                            <x-label for="published_at" :value="__('When should the post be published?')" />
+                            <div class="flex flex-row items-center">
+                                <div>
+                                    <x-input id="published_at" name="published_at" type="datetime-local" class="block mt-1 w-full" value="{{ (old('published_at') === null) ? now()->format('Y-m-d\TH:i') : '' }}" min="1971-01-01T00:00" max="2038-01-09T03:14"/>
+                                    @error('published_at') <span class="text-red-500">{{ $message }}</span> @enderror
+                                </div>
+                            </div>
+                            
+                            <x-label for="published_at">
+                                <small>You can also <button class="text-indigo-500 dark:text-indigo-300" title="Clear the input field" type="button" role="button" onclick="clearPublishedAtInput()">leave it blank</button> to save the post as a draft.</small>
+                            </x-label>
+                        </div>
+
                         @if(config('blog.withTags'))
                         <livewire:tag-manager />
                         @endif
                     </fieldset>
             
-                    <div class="flex items-center justify-end mt-4">
+                    <div class="flex items-center justify-end mt-4 mb-2">
+                        <div>
+                            <div class="flex flex-row items-center">
+                                <x-label class="cursor-pointer" for="is_draft" :value="__('Save as draft')" title="Saves the post without a publish date, making it hidden."/>
+                                <x-input id="is_draft" name="is_draft" value="1" :checked="old('is_draft') || isset($post) && $post->published_at === null" type="checkbox" class="block mx-2 cursor-pointer" title="Press to toggle"/>
+                            </div>
+                            @error('is_draft') <span class="text-red-500">{{ $message }}</span> @enderror
+                        </div>
+
                         <x-button type="submit" class="ml-4">
                             {{ __('Save') }}
                         </x-button>
@@ -59,4 +81,12 @@
 			</section>
         </div>
     </div>
+
+    @push('scripts')
+    <script>
+        function clearPublishedAtInput() { 
+            document.getElementById('published_at').value = null;
+        }
+    </script>
+    @endpush
 </x-app-layout>

--- a/resources/views/post/edit.blade.php
+++ b/resources/views/post/edit.blade.php
@@ -55,13 +55,35 @@
                             <x-input id="featured_image" name="featured_image" :value="old('featured_image') ?? $post->featured_image" type="text" class="block mt-1 w-full" maxlength="255" placeholder="https://example.org/static/image.jpg"/>
                             @error('featured_image') <span class="text-red-500">{{ $message }}</span> @enderror
                         </div>
+                        
+                        <div class="mt-3">
+                            <x-label for="published_at" :value="__('When should the post be published?')" />
+                            <div class="flex flex-row items-center">
+                                <div>
+                                    <x-input id="published_at" name="published_at" :value="optional($post->published_at)->format('Y-m-d\TH:i')" type="datetime-local" class="block mt-1 w-full" placeholder="{{ now() }}"/>
+                                    @error('published_at') <span class="text-red-500">{{ $message }}</span> @enderror
+                                </div>
+                            </div>
+                            
+                            <x-label for="published_at">
+                                <small>You can also <button class="text-indigo-500 dark:text-indigo-300" title="Clear the input field" type="button" role="button" onclick="clearPublishedAtInput()">leave it blank</button> to save the post as a draft.</small>
+                            </x-label>
+                        </div>
 
                         @if(config('blog.withTags'))
                         <livewire:tag-manager :currenttags="$post->tags" />
                         @endif
                     </fieldset>
 
-                    <div class="flex items-center justify-end mt-4">
+                    <div class="flex items-center justify-end mt-4 mb-2">
+                        <div>
+                            <div class="flex flex-row items-center">
+                                <x-label class="cursor-pointer" for="is_draft" :value="__('Save as draft')" title="Saves the post without a publish date, making it hidden."/>
+                                <x-input id="is_draft" name="is_draft" value="1" :checked="old('is_draft') || isset($post) && $post->published_at === null" type="checkbox" class="block mx-2 cursor-pointer" title="Press to toggle"/>
+                            </div>
+                            @error('is_draft') <span class="text-red-500">{{ $message }}</span> @enderror
+                        </div>
+
                         <x-button type="submit" class="ml-4">
                             {{ __('Save') }}
                         </x-button>
@@ -70,4 +92,12 @@
 			</section>
         </div>
     </div>
+
+    @push('scripts')
+    <script>
+        function clearPublishedAtInput() { 
+            document.getElementById('published_at').value = null;
+        }
+    </script>
+    @endpush
 </x-app-layout>

--- a/resources/views/post/show.blade.php
+++ b/resources/views/post/show.blade.php
@@ -10,8 +10,12 @@
 	<meta property="og:description" content="{{ $post->description }}">
 	<meta property="og:image" content="{{ $post->featured_image }}">
 	<meta property="og:url" content="{{ route('posts.show', ['post' => $post]) }}">
-	<meta property="og:article:published_time" content="{{ $post->created_at }}">
+	@if($post->isPublished())
+	<meta property="og:article:published_time" content="{{ $post->published_at }}">
+	@endif
+	@if(config('blog.showUpdatedAt'))
 	<meta property="og:article:modified_time " content="{{ $post->updated_at }}">
+	@endif
 	<meta name="twitter:card" content="summary_large_image">
 	@endpush
 
@@ -23,7 +27,16 @@
 						<thead>
 							<tr>
 								<th class="text-left">
-									<h1 class="text-3xl font-bold">{{ $post->title }}</h1>
+									<h1 class="text-3xl font-bold">
+										@if($post->isPublished())
+										{{ $post->title }}
+										@else
+										<span class="opacity-75" title="This post has not yet been published">
+											Draft: 
+										</span>
+										<i>{{ $post->title }}</i>
+										@endif
+									</h1>
 								</th>
 								<td class="text-right whitespace-nowrap align-top pt-2 pl-5 hidden sm:block">
 									@can('update', $post)
@@ -43,14 +56,16 @@
 								</span>
 								<x-link :href="route('posts.index', ['author' => $post->author])" rel="author">{{ $post->author->name }}</x-link>
 							</li>
+							@if($post->isPublished())
 							<li class="mx-1 opacity-75" name="published_time">
-								<time datetime="{{ $post->created_at }}">{{ $post->created_at->format('Y-m-d g:ia') }}</time>.
+								<time datetime="{{ $post->published_at }}" title="Published {{ $post->published_at }}">{{ $post->published_at->format('Y-m-d g:ia') }}</time>.
 							</li>
-							@if($post->created_at !== $post->updated_at)
+							@if(config('blog.showUpdatedAt') && $post->published_at !== $post->updated_at)
 							<li class="mx-1 opacity-75" name="modified_time">
 								Updated
-								<time datetime="{{ $post->updated_at }}">{{ $post->updated_at->format('Y-m-d g:ia') }}</time>.
+								<time datetime="{{ $post->updated_at }}" title="Updated {{ $post->updated_at }}">{{ $post->updated_at->format('Y-m-d g:ia') }}</time>.
 							</li>
+							@endif
 							@endif
 							@if(config('blog.withTags') && $post->tags)
 							<li class="mx-1" name="tags">
@@ -82,7 +97,7 @@
 									<a href="{{ route('posts.index', ['author' => $comment->user]) }}">
 										<small class="opacity-75">&commat;</small>{{ $comment->user->name }}:
 									</a>
-									@if($comment->created_at != $comment->updated_at)
+									@if($comment->published_at != $comment->updated_at)
 										<i class="text-xs opacity-75" title="This comment was last updated {{ $comment->updated_at }}">Edited</i>
 									@endif
 								</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,8 +24,11 @@ Route::get('/', function () {
     ]);
 })->name('home');
 
+
 Route::resource('posts', PostController::class);
- 
+Route::post('/posts/{post}/publish', [PostController::class, 'publish'])->name('posts.publish');
+Route::post('/posts/{post}/unpublish', [PostController::class, 'unpublish'])->name('posts.unpublish');
+
 Route::resource('comments', CommentController::class)->only([
     'edit',
     'destroy',


### PR DESCRIPTION
# Implements features from issue #3.

## Main Changes:

### Migration adds a nullable 'published_at' column to the posts table
```php
$table->timestamp('published_at')
    ->after('updated_at')
    ->nullable();
```

### Adds a method to the Post model to see if the post is published or if it is still a draft.
```php
public function isPublished(): bool
{
    return ($this->published_at !== null) && $this->published_at->isPast();
}
```

### Adds a config option to disable the display of updated_at timestamps showing on posts.
```php
// Should the updated at time be shown on edited posts?
'showUpdatedAt' =### true, // Default: true
```

### Updates the post factory to set the related user model to an author, and to have a chance to make the post be a draft.
```php
'published_at' =### rand(0, 20) < 1 ? null : $this->faker->dateTimeThisYear(),
```

### Add a datetime picker and a checkbox to indicate if a post is a draft to the create and update form.
### 
![Screenshot of the new form inputs](https://user-images.githubusercontent.com/95144705/155299630-499107e4-4e25-438d-b3c9-b0804ad95672.png)
  
The form request intercepts the input data and checks if the checkbox is ticked. If it is, it sets the publish date to `null`, making it save as a draft. The input can also be left blank to accomplish the same thing.

## More changes:
- Create a dynamic global scope that by default hides posts that are not published from collections. However, Admins can see all drafts, and authors can see their own drafts. The scope is in `\App\Scopes\PublishedScope`

- Adds authorization checks to the Post view permission to deny requests for unpublished posts, unless the user has permission to view the draft.

  
- Adds two new resource routes, `/posts/{post}/publish` and `/posts/{post}/unpublish` which can be used to quickly publish and unpublish a post. The authorization for these inherits the post `update` policy.

- Update the code to reflect the addition of publish dates, by for example showing the publish date instead of the created_at date in the posts.

## About the PR
The PR is tested and designed to be compatible with previous versions and should be able to merge into existing installs that still shares the same codebase as the Master.