### PR TITLE
Add Linguist configuration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,4 @@
 
 /.github export-ignore
 CHANGELOG.md export-ignore
+public/js/app.js linguist-generated


### PR DESCRIPTION
Makes so the compiled asset is not shown in stats, and is collapsed in diffs. See https://github.com/github/linguist/blob/master/docs/overrides.md#summary