### PR TITLE
Remove BrowserSync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,6 @@
                 "alpinejs": "^3.4.2",
                 "autoprefixer": "^10.4.2",
                 "axios": "^1.7",
-                "browser-sync": "^3.0.2",
-                "browser-sync-webpack-plugin": "^2.3.0",
                 "laravel-mix": "^6.0.6",
                 "lodash": "^4.17.19",
                 "postcss": "^8.4.31",
@@ -2209,12 +2207,6 @@
                 "node": ">=14"
             }
         },
-        "node_modules/@socket.io/component-emitter": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
-            "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
-            "dev": true
-        },
         "node_modules/@tailwindcss/forms": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.4.1.tgz",
@@ -2337,21 +2329,6 @@
             "dev": true,
             "dependencies": {
                 "@types/express-serve-static-core": "*",
-                "@types/node": "*"
-            }
-        },
-        "node_modules/@types/cookie": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
-            "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
-            "dev": true
-        },
-        "node_modules/@types/cors": {
-            "version": "2.8.17",
-            "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
-            "integrity": "sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==",
-            "dev": true,
-            "dependencies": {
                 "@types/node": "*"
             }
         },
@@ -3005,24 +2982,6 @@
                 "inherits": "2.0.3"
             }
         },
-        "node_modules/async": {
-            "version": "2.6.4",
-            "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-            "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-            "dev": true,
-            "dependencies": {
-                "lodash": "^4.17.14"
-            }
-        },
-        "node_modules/async-each-series": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz",
-            "integrity": "sha512-p4jj6Fws4Iy2m0iCmI2am2ZNZCgbdgE+P8F/8csmn2vx7ixXrO2zGcuNsD46X5uZSVecmkEy/M06X2vG8KD6dQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -3170,15 +3129,6 @@
                 }
             ]
         },
-        "node_modules/base64id": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
-            "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
-            "dev": true,
-            "engines": {
-                "node": "^4.5.0 || >= 5.9"
-            }
-        },
         "node_modules/batch": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -3314,90 +3264,6 @@
             "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
             "dev": true
         },
-        "node_modules/browser-sync": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-3.0.2.tgz",
-            "integrity": "sha512-PC9c7aWJFVR4IFySrJxOqLwB9ENn3/TaXCXtAa0SzLwocLN3qMjN+IatbjvtCX92BjNXsY6YWg9Eb7F3Wy255g==",
-            "dev": true,
-            "dependencies": {
-                "browser-sync-client": "^3.0.2",
-                "browser-sync-ui": "^3.0.2",
-                "bs-recipes": "1.3.4",
-                "chalk": "4.1.2",
-                "chokidar": "^3.5.1",
-                "connect": "3.6.6",
-                "connect-history-api-fallback": "^1",
-                "dev-ip": "^1.0.1",
-                "easy-extender": "^2.3.4",
-                "eazy-logger": "^4.0.1",
-                "etag": "^1.8.1",
-                "fresh": "^0.5.2",
-                "fs-extra": "3.0.1",
-                "http-proxy": "^1.18.1",
-                "immutable": "^3",
-                "micromatch": "^4.0.2",
-                "opn": "5.3.0",
-                "portscanner": "2.2.0",
-                "raw-body": "^2.3.2",
-                "resp-modifier": "6.0.2",
-                "rx": "4.1.0",
-                "send": "0.16.2",
-                "serve-index": "1.9.1",
-                "serve-static": "1.13.2",
-                "server-destroy": "1.0.1",
-                "socket.io": "^4.4.1",
-                "ua-parser-js": "^1.0.33",
-                "yargs": "^17.3.1"
-            },
-            "bin": {
-                "browser-sync": "dist/bin.js"
-            },
-            "engines": {
-                "node": ">= 8.0.0"
-            }
-        },
-        "node_modules/browser-sync-client": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-3.0.2.tgz",
-            "integrity": "sha512-tBWdfn9L0wd2Pjuz/NWHtNEKthVb1Y67vg8/qyGNtCqetNz5lkDkFnrsx5UhPNPYUO8vci50IWC/BhYaQskDiQ==",
-            "dev": true,
-            "dependencies": {
-                "etag": "1.8.1",
-                "fresh": "0.5.2",
-                "mitt": "^1.1.3"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "node_modules/browser-sync-ui": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-3.0.2.tgz",
-            "integrity": "sha512-V3FwWAI+abVbFLTyJjXJlCMBwjc3GXf/BPGfwO2fMFACWbIGW9/4SrBOFYEOOtqzCjQE0Di+U3VIb7eES4omNA==",
-            "dev": true,
-            "dependencies": {
-                "async-each-series": "0.1.1",
-                "chalk": "4.1.2",
-                "connect-history-api-fallback": "^1",
-                "immutable": "^3",
-                "server-destroy": "1.0.1",
-                "socket.io-client": "^4.4.1",
-                "stream-throttle": "^0.1.3"
-            }
-        },
-        "node_modules/browser-sync-webpack-plugin": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/browser-sync-webpack-plugin/-/browser-sync-webpack-plugin-2.3.0.tgz",
-            "integrity": "sha512-MDvuRrTCtoL11dTdwMymo9CNJvYxJoW67gOO61cThfzHNX40S5WcBU+0bVQ86ll7r7aNpNgyzxF7RtnXMTDbyA==",
-            "dev": true,
-            "dependencies": {
-                "lodash": "^4"
-            },
-            "peerDependencies": {
-                "browser-sync": "^2",
-                "webpack": "^1 || ^2 || ^3 || ^4 || ^5"
-            }
-        },
         "node_modules/browserify-aes": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
@@ -3519,12 +3385,6 @@
             "engines": {
                 "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
             }
-        },
-        "node_modules/bs-recipes": {
-            "version": "1.3.4",
-            "resolved": "https://registry.npmjs.org/bs-recipes/-/bs-recipes-1.3.4.tgz",
-            "integrity": "sha512-BXvDkqhDNxXEjeGM8LFkSbR+jzmP/CYpCiVKYn+soB1dDldeU15EBNDkwVXndKuX35wnNUaPd0qSoQEAkmQtMw==",
-            "dev": true
         },
         "node_modules/buffer": {
             "version": "4.9.2",
@@ -3903,30 +3763,6 @@
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "dev": true
         },
-        "node_modules/connect": {
-            "version": "3.6.6",
-            "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
-            "integrity": "sha512-OO7axMmPpu/2XuX1+2Yrg0ddju31B6xLZMWkJ5rYBu4YRmRVlOjvlY6kw2FJKiAzyxGwnrDUAG4s1Pf0sbBMCQ==",
-            "dev": true,
-            "dependencies": {
-                "debug": "2.6.9",
-                "finalhandler": "1.1.0",
-                "parseurl": "~1.3.2",
-                "utils-merge": "1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.10.0"
-            }
-        },
-        "node_modules/connect-history-api-fallback": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
-            "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
         "node_modules/consola": {
             "version": "2.15.3",
             "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
@@ -3972,15 +3808,6 @@
             "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
             "dev": true
         },
-        "node_modules/cookie": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-            "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
         "node_modules/cookie-signature": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -4005,19 +3832,6 @@
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
             "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
             "dev": true
-        },
-        "node_modules/cors": {
-            "version": "2.8.5",
-            "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-            "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-            "dev": true,
-            "dependencies": {
-                "object-assign": "^4",
-                "vary": "^1"
-            },
-            "engines": {
-                "node": ">= 0.10"
-            }
         },
         "node_modules/cosmiconfig": {
             "version": "7.1.0",
@@ -4427,29 +4241,11 @@
                 "minimalistic-assert": "^1.0.0"
             }
         },
-        "node_modules/destroy": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-            "integrity": "sha512-3NdhDuEXnfun/z7x9GOElY49LoqVHoGScmOKwmxhsS8N5Y+Z8KyPPDnaSzqWgYt/ji4mqwfTS34Htrk0zPIXVg==",
-            "dev": true
-        },
         "node_modules/detect-node": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
             "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
             "dev": true
-        },
-        "node_modules/dev-ip": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz",
-            "integrity": "sha512-LmVkry/oDShEgSZPNgqCIp2/TlqtExeGmymru3uCELnfyjY11IzpAproLYs+1X88fXO6DBoYP3ul2Xo2yz2j6A==",
-            "dev": true,
-            "bin": {
-                "dev-ip": "lib/dev-ip.js"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
         },
         "node_modules/didyoumean": {
             "version": "1.2.2",
@@ -4630,30 +4426,6 @@
             "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
             "dev": true
         },
-        "node_modules/easy-extender": {
-            "version": "2.3.4",
-            "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.4.tgz",
-            "integrity": "sha512-8cAwm6md1YTiPpOvDULYJL4ZS6WfM5/cTeVVh4JsvyYZAoqlRVUpHL9Gr5Fy7HA6xcSZicUia3DeAgO3Us8E+Q==",
-            "dev": true,
-            "dependencies": {
-                "lodash": "^4.17.10"
-            },
-            "engines": {
-                "node": ">= 4.0.0"
-            }
-        },
-        "node_modules/eazy-logger": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-4.0.1.tgz",
-            "integrity": "sha512-2GSFtnnC6U4IEKhEI7+PvdxrmjJ04mdsj3wHZTFiw0tUtG4HCWzTr13ZYTk8XOGnA1xQMaDljoBOYlk3D/MMSw==",
-            "dev": true,
-            "dependencies": {
-                "chalk": "4.1.2"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
         "node_modules/ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -4710,95 +4482,6 @@
             "engines": {
                 "node": ">= 0.8"
             }
-        },
-        "node_modules/engine.io": {
-            "version": "6.5.5",
-            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.5.tgz",
-            "integrity": "sha512-C5Pn8Wk+1vKBoHghJODM63yk8MvrO9EWZUfkAt5HAqIgPE4/8FF0PEGHXtEd40l223+cE5ABWuPzm38PHFXfMA==",
-            "dev": true,
-            "dependencies": {
-                "@types/cookie": "^0.4.1",
-                "@types/cors": "^2.8.12",
-                "@types/node": ">=10.0.0",
-                "accepts": "~1.3.4",
-                "base64id": "2.0.0",
-                "cookie": "~0.4.1",
-                "cors": "~2.8.5",
-                "debug": "~4.3.1",
-                "engine.io-parser": "~5.2.1",
-                "ws": "~8.17.1"
-            },
-            "engines": {
-                "node": ">=10.2.0"
-            }
-        },
-        "node_modules/engine.io-client": {
-            "version": "6.5.4",
-            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.4.tgz",
-            "integrity": "sha512-GeZeeRjpD2qf49cZQ0Wvh/8NJNfeXkXXcoGh+F77oEAgo9gUHwT1fCRxSNU+YEEaysOJTnsFHmM5oAcPy4ntvQ==",
-            "dev": true,
-            "dependencies": {
-                "@socket.io/component-emitter": "~3.1.0",
-                "debug": "~4.3.1",
-                "engine.io-parser": "~5.2.1",
-                "ws": "~8.17.1",
-                "xmlhttprequest-ssl": "~2.0.0"
-            }
-        },
-        "node_modules/engine.io-client/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/engine.io-client/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
-        },
-        "node_modules/engine.io-parser": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.2.tgz",
-            "integrity": "sha512-RcyUFKA93/CXH20l4SoVvzZfrSDMOTUS3bWVpTt2FuFP+XYrL8i8oonHP7WInRyVHXh0n/ORtoeiE1os+8qkSw==",
-            "dev": true,
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
-        "node_modules/engine.io/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/engine.io/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
         },
         "node_modules/enhanced-resolve": {
             "version": "5.17.1",
@@ -5280,24 +4963,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/finalhandler": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
-            "integrity": "sha512-ejnvM9ZXYzp6PUPUyQBMBf0Co5VX2gr5H2VQe2Ui2jWXNlxv+PYZo8wpAymJNJdLsG1R4p+M4aynF8KuoUEwRw==",
-            "dev": true,
-            "dependencies": {
-                "debug": "2.6.9",
-                "encodeurl": "~1.0.1",
-                "escape-html": "~1.0.3",
-                "on-finished": "~2.3.0",
-                "parseurl": "~1.3.2",
-                "statuses": "~1.3.1",
-                "unpipe": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/find-cache-dir": {
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
@@ -5428,17 +5093,6 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.6"
-            }
-        },
-        "node_modules/fs-extra": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
-            "integrity": "sha512-V3Z3WZWVUYd8hoCL5xfXJCaHWYzmtwW5XWYSlLgERi8PWd8bx1kUHUk8L1BT57e49oKnDDD180mjfrHc1yA9rg==",
-            "dev": true,
-            "dependencies": {
-                "graceful-fs": "^4.1.2",
-                "jsonfile": "^3.0.0",
-                "universalify": "^0.1.0"
             }
         },
         "node_modules/fs-monkey": {
@@ -6089,15 +5743,6 @@
                 "node": ">=4.0.0"
             }
         },
-        "node_modules/immutable": {
-            "version": "3.8.2",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
-            "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/import-fresh": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -6257,15 +5902,6 @@
                 "node": ">=0.12.0"
             }
         },
-        "node_modules/is-number-like": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz",
-            "integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
-            "dev": true,
-            "dependencies": {
-                "lodash.isfinite": "^3.3.2"
-            }
-        },
         "node_modules/is-plain-obj": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
@@ -6300,15 +5936,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/is-wsl": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-            "integrity": "sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/isarray": {
@@ -6428,15 +6055,6 @@
             },
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/jsonfile": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
-            "integrity": "sha512-oBko6ZHlubVB5mRFkur5vgYR1UyqX+S6Y/oCfLhqNdcc2fYFlDpIoNc7AfKS1KOGcnNAkvsr0grLck9ANM815w==",
-            "dev": true,
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
             }
         },
         "node_modules/junk": {
@@ -6595,12 +6213,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/limiter": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
-            "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==",
-            "dev": true
-        },
         "node_modules/lines-and-columns": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -6658,12 +6270,6 @@
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
             "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
-            "dev": true
-        },
-        "node_modules/lodash.isfinite": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
-            "integrity": "sha512-7FGG40uhC8Mm633uKW1r58aElFlBlxCrg9JfSi3P6aYiWmfiWF0PgMd86ZUsxE5GwWPdHoS2+48bwTh2VPkIQA==",
             "dev": true
         },
         "node_modules/lodash.isplainobject": {
@@ -6843,15 +6449,6 @@
             "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
             "dev": true
         },
-        "node_modules/mime": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-            "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
-            "dev": true,
-            "bin": {
-                "mime": "cli.js"
-            }
-        },
         "node_modules/mime-db": {
             "version": "1.52.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -6971,12 +6568,6 @@
             "engines": {
                 "node": ">=16 || 14 >=14.17"
             }
-        },
-        "node_modules/mitt": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.2.0.tgz",
-            "integrity": "sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw==",
-            "dev": true
         },
         "node_modules/ms": {
             "version": "2.0.0",
@@ -7237,18 +6828,6 @@
             "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
             "dev": true
         },
-        "node_modules/on-finished": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-            "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
-            "dev": true,
-            "dependencies": {
-                "ee-first": "1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/on-headers": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
@@ -7309,18 +6888,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/opn": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
-            "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
-            "dev": true,
-            "dependencies": {
-                "is-wsl": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/os-browserify": {
@@ -7609,20 +7176,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/portscanner": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.2.0.tgz",
-            "integrity": "sha512-IFroCz/59Lqa2uBvzK3bKDbDDIEaAY8XJ1jFxcLWTqosrsc32//P4VuSB2vZXoHiHqOmx8B5L5hnKOxL/7FlPw==",
-            "dev": true,
-            "dependencies": {
-                "async": "^2.6.0",
-                "is-number-like": "^1.0.3"
-            },
-            "engines": {
-                "node": ">=0.4",
-                "npm": ">=1.0.0"
             }
         },
         "node_modules/postcss": {
@@ -8643,19 +8196,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/resp-modifier": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-6.0.2.tgz",
-            "integrity": "sha512-U1+0kWC/+4ncRFYqQWTx/3qkfE6a4B/h3XXgmXypfa0SPZ3t7cbbaFk297PjQS/yov24R18h6OZe6iZwj3NSLw==",
-            "dev": true,
-            "dependencies": {
-                "debug": "^2.2.0",
-                "minimatch": "^3.0.2"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
         "node_modules/retry": {
             "version": "0.13.1",
             "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -8722,12 +8262,6 @@
             "dependencies": {
                 "queue-microtask": "^1.2.2"
             }
-        },
-        "node_modules/rx": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-            "integrity": "sha512-CiaiuN6gapkdl+cZUr67W6I8jquN4lkak3vtIsIWCl4XIPP8ffsoyN6/+PuGXnQy8Cu8W2y9Xxh31Rq4M6wUug==",
-            "dev": true
         },
         "node_modules/safe-buffer": {
             "version": "5.2.1",
@@ -8825,75 +8359,6 @@
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true
         },
-        "node_modules/send": {
-            "version": "0.16.2",
-            "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-            "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
-            "dev": true,
-            "dependencies": {
-                "debug": "2.6.9",
-                "depd": "~1.1.2",
-                "destroy": "~1.0.4",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "fresh": "0.5.2",
-                "http-errors": "~1.6.2",
-                "mime": "1.4.1",
-                "ms": "2.0.0",
-                "on-finished": "~2.3.0",
-                "range-parser": "~1.2.0",
-                "statuses": "~1.4.0"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/send/node_modules/depd": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-            "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/send/node_modules/http-errors": {
-            "version": "1.6.3",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-            "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
-            "dev": true,
-            "dependencies": {
-                "depd": "~1.1.2",
-                "inherits": "2.0.3",
-                "setprototypeof": "1.1.0",
-                "statuses": ">= 1.4.0 < 2"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/send/node_modules/inherits": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
-            "dev": true
-        },
-        "node_modules/send/node_modules/setprototypeof": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-            "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-            "dev": true
-        },
-        "node_modules/send/node_modules/statuses": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-            "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
         "node_modules/serialize-javascript": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
@@ -8965,27 +8430,6 @@
             "engines": {
                 "node": ">= 0.6"
             }
-        },
-        "node_modules/serve-static": {
-            "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
-            "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
-            "dev": true,
-            "dependencies": {
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "parseurl": "~1.3.2",
-                "send": "0.16.2"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/server-destroy": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
-            "integrity": "sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ==",
-            "dev": true
         },
         "node_modules/set-function-length": {
             "version": "1.2.1",
@@ -9109,154 +8553,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/socket.io": {
-            "version": "4.7.4",
-            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.4.tgz",
-            "integrity": "sha512-DcotgfP1Zg9iP/dH9zvAQcWrE0TtbMVwXmlV4T4mqsvY+gw+LqUGPfx2AoVyRk0FLME+GQhufDMyacFmw7ksqw==",
-            "dev": true,
-            "dependencies": {
-                "accepts": "~1.3.4",
-                "base64id": "~2.0.0",
-                "cors": "~2.8.5",
-                "debug": "~4.3.2",
-                "engine.io": "~6.5.2",
-                "socket.io-adapter": "~2.5.2",
-                "socket.io-parser": "~4.2.4"
-            },
-            "engines": {
-                "node": ">=10.2.0"
-            }
-        },
-        "node_modules/socket.io-adapter": {
-            "version": "2.5.5",
-            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
-            "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
-            "dev": true,
-            "dependencies": {
-                "debug": "~4.3.4",
-                "ws": "~8.17.1"
-            }
-        },
-        "node_modules/socket.io-adapter/node_modules/debug": {
-            "version": "4.3.5",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-            "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/socket.io-adapter/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
-        },
-        "node_modules/socket.io-client": {
-            "version": "4.7.4",
-            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.4.tgz",
-            "integrity": "sha512-wh+OkeF0rAVCrABWQBaEjLfb7DVPotMbu0cgWgyR0v6eA4EoVnAwcIeIbcdTE3GT/H3kbdLl7OoH2+asoDRIIg==",
-            "dev": true,
-            "dependencies": {
-                "@socket.io/component-emitter": "~3.1.0",
-                "debug": "~4.3.2",
-                "engine.io-client": "~6.5.2",
-                "socket.io-parser": "~4.2.4"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
-        "node_modules/socket.io-client/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/socket.io-client/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
-        },
-        "node_modules/socket.io-parser": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
-            "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
-            "dev": true,
-            "dependencies": {
-                "@socket.io/component-emitter": "~3.1.0",
-                "debug": "~4.3.1"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
-        "node_modules/socket.io-parser/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/socket.io-parser/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
-        },
-        "node_modules/socket.io/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/socket.io/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
         },
         "node_modules/sockjs": {
             "version": "0.3.24",
@@ -9400,15 +8696,6 @@
             "deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility",
             "dev": true
         },
-        "node_modules/statuses": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-            "integrity": "sha512-wuTCPGlJONk/a1kqZ4fQM2+908lC7fa7nPYpTC1EhnvqLX/IICbeP1OZGDtA374trpSq68YubKUMo8oRhN46yg==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
         "node_modules/std-env": {
             "version": "3.7.0",
             "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.7.0.tgz",
@@ -9437,28 +8724,6 @@
                 "to-arraybuffer": "^1.0.0",
                 "xtend": "^4.0.0"
             }
-        },
-        "node_modules/stream-throttle": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
-            "integrity": "sha512-889+B9vN9dq7/vLbGyuHeZ6/ctf5sNuGWsDy89uNxkFTAgzy0eK7+w5fL3KLNRTkLle7EgZGvHUphZW0Q26MnQ==",
-            "dev": true,
-            "dependencies": {
-                "commander": "^2.2.0",
-                "limiter": "^1.0.5"
-            },
-            "bin": {
-                "throttleproxy": "bin/throttleproxy.js"
-            },
-            "engines": {
-                "node": ">= 0.10.0"
-            }
-        },
-        "node_modules/stream-throttle/node_modules/commander": {
-            "version": "2.20.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-            "dev": true
         },
         "node_modules/string_decoder": {
             "version": "1.3.0",
@@ -10031,29 +9296,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/ua-parser-js": {
-            "version": "1.0.37",
-            "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.37.tgz",
-            "integrity": "sha512-bhTyI94tZofjo+Dn8SN6Zv8nBDvyXTymAdM3LDI/0IboIUwTu1rEhW7v2TfiVsoYWgkQ4kOVqnI8APUFbIQIFQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/ua-parser-js"
-                },
-                {
-                    "type": "paypal",
-                    "url": "https://paypal.me/faisalman"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/faisalman"
-                }
-            ],
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/undici-types": {
             "version": "5.26.5",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -10098,15 +9340,6 @@
             "dev": true,
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/universalify": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-            "dev": true,
-            "engines": {
-                "node": ">= 4.0.0"
             }
         },
         "node_modules/unpipe": {
@@ -10769,15 +10002,6 @@
                 "utf-8-validate": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/xmlhttprequest-ssl": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
-            "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.4.0"
             }
         },
         "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,6 @@
         "alpinejs": "^3.4.2",
         "autoprefixer": "^10.4.2",
         "axios": "^1.7",
-        "browser-sync": "^3.0.2",
-        "browser-sync-webpack-plugin": "^2.3.0",
         "laravel-mix": "^6.0.6",
         "lodash": "^4.17.19",
         "postcss": "^8.4.31",

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -16,8 +16,3 @@ mix.js('resources/js/app.js', 'public/js').postCss('resources/css/app.css', 'pub
     require('tailwindcss'),
     require('autoprefixer'),
 ]);
-
-mix.browserSync({
-    proxy: 'localhost:8000',
-    open: false,
-});


### PR DESCRIPTION
These packages don't seem to be supported anymore, and are blocking NPM installs due to the broken dependency tree.